### PR TITLE
generate query types that can be reused; alpha release

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,7 @@ yarn.lock
 dist/
 .cache-loader/
 .awcache/
+
+tests/*
+coverage/*
+jest.config.js

--- a/README.md
+++ b/README.md
@@ -68,10 +68,15 @@ export let genRouter = {
   a: {
     name: "a",
     raw: "a",
-    path: <T = { a?: string; b?: string }>(queries?: T) => `/a?${qsStringify(queries)}`,
-    go: <T = { a?: string; b?: string }>(queries?: T) => switchPath(`/a?${qsStringify(queries)}`),
+    path: <T = IGenQueryA>(queries?: T) => `/a?${qsStringify(queries)}`,
+    go: <T = IGenQueryA>(queries?: T) => switchPath(`/a?${qsStringify(queries)}`),
   },
 };
+
+export interface IGenQueryA {
+  a?: string;
+  b?: string;
+}
 ```
 
 - Nested router

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/router-code-generator",
-  "version": "0.1.3",
+  "version": "0.1.4-a2",
   "description": "",
   "main": "./lib/generator.js",
   "scripts": {

--- a/tests/generated-queries.ts
+++ b/tests/generated-queries.ts
@@ -2,7 +2,12 @@ export let genRouter = {
   a: {
     name: "a",
     raw: "a",
-    path: <T = { a?: string; b?: string }>(queries?: T) => `/a?${qsStringify(queries)}`,
-    go: <T = { a?: string; b?: string }>(queries?: T) => switchPath(`/a?${qsStringify(queries)}`),
+    path: <T = IGenQueryA>(queries?: T) => `/a?${qsStringify(queries)}`,
+    go: <T = IGenQueryA>(queries?: T) => switchPath(`/a?${qsStringify(queries)}`),
   },
 };
+
+export interface IGenQueryA {
+  a?: string;
+  b?: string;
+}


### PR DESCRIPTION
Business code might need query types so generated interfaces are added in this change. The names are generated based on the path.
