### PR TITLE
simplify query parameter; alpha release

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ export let genRouter = {
   a: {
     name: "a",
     raw: "a",
-    path: <T = IGenQueryA>(queries?: T) => `/a?${qsStringify(queries)}`,
-    go: <T = IGenQueryA>(queries?: T) => switchPath(`/a?${qsStringify(queries)}`),
+    path: (queries?: IGenQueryA) => `/a?${qsStringify(queries)}`,
+    go: (queries?: IGenQueryA) => switchPath(`/a?${qsStringify(queries)}`),
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/router-code-generator",
-  "version": "0.2.0",
+  "version": "0.2.1-a1",
   "description": "",
   "main": "./lib/generator.js",
   "scripts": {
@@ -17,7 +17,6 @@
   },
   "keywords": [],
   "author": "",
-  "private": true,
   "devDependencies": {
     "@jimengio/flex-styles": "^0.1.5",
     "@jimengio/ruled-router": "^0.2.15",

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -74,8 +74,8 @@ function generateField(rule: IRouteRule, basePath: string, trackQueryTypse: (nam
   let resultObj = ` {
 		name: ${nameString},
 		raw: ${rawPath},
-		path: <T=${queryName}>(${paramsList} queries?: T) => ${pathInString},
-		go: <T=${queryName}>(${paramsList} queries?: T) => switchPath(${pathInString}),
+		path: (${paramsList} queries?: ${queryName}) => ${pathInString},
+		go: (${paramsList} queries?: ${queryName}) => switchPath(${pathInString}),
 		${fieldsInString}
 	}
 	`;

--- a/tests/generated-home-path.ts
+++ b/tests/generated-home-path.ts
@@ -2,8 +2,8 @@ export let genRouter = {
   $: {
     name: "home",
     raw: "",
-    path: <T = IGenQuery$>(queries?: T) => `/?${qsStringify(queries)}`,
-    go: <T = IGenQuery$>(queries?: T) => switchPath(`/?${qsStringify(queries)}`),
+    path: (queries?: IGenQuery$) => `/?${qsStringify(queries)}`,
+    go: (queries?: IGenQuery$) => switchPath(`/?${qsStringify(queries)}`),
   },
 };
 

--- a/tests/generated-kebab-path.ts
+++ b/tests/generated-kebab-path.ts
@@ -7,8 +7,8 @@ export let genRouter = {
     cD: {
       name: "c-d",
       raw: "c-d",
-      path: <T = IGenQueryABCD>(queries?: T) => `/a-b/c-d?${qsStringify(queries)}`,
-      go: <T = IGenQueryABCD>(queries?: T) => switchPath(`/a-b/c-d?${qsStringify(queries)}`),
+      path: (queries?: IGenQueryABCD) => `/a-b/c-d?${qsStringify(queries)}`,
+      go: (queries?: IGenQueryABCD) => switchPath(`/a-b/c-d?${qsStringify(queries)}`),
     },
   },
 };

--- a/tests/generated-queries.ts
+++ b/tests/generated-queries.ts
@@ -2,8 +2,8 @@ export let genRouter = {
   a: {
     name: "a",
     raw: "a",
-    path: <T = IGenQueryA>(queries?: T) => `/a?${qsStringify(queries)}`,
-    go: <T = IGenQueryA>(queries?: T) => switchPath(`/a?${qsStringify(queries)}`),
+    path: (queries?: IGenQueryA) => `/a?${qsStringify(queries)}`,
+    go: (queries?: IGenQueryA) => switchPath(`/a?${qsStringify(queries)}`),
   },
 };
 


### PR DESCRIPTION
Generate simpler code so that VS Code check `query` params in the methods.
