### PR TITLE
initial support for array param in queries; alpha release

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Recommended implementation for query string:
 ```ts
 import queryString from "query-string";
 
-let qsStringify = (queries: { [k: string]: string | string[] }) => {
+let qsStringify = (queries: { [k: string]: any }) => {
   return queryString.stringify(queries, { arrayFormat: "bracket" });
 };
 ```

--- a/README.md
+++ b/README.md
@@ -170,6 +170,20 @@ export interface GenRouterTypeTree {
 }
 ```
 
+### `qsStringify`
+
+Recommended implementation for query string:
+
+```ts
+import queryString from "query-string";
+
+let qsStringify = (queries: { [k: string]: string | string[] }) => {
+  return queryString.stringify(queries, { arrayFormat: "bracket" });
+};
+```
+
+Also the parser should use the same formatter `bracket`.
+
 ### License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/router-code-generator",
-  "version": "0.2.4",
+  "version": "0.2.5-a1",
   "description": "",
   "main": "./lib/generator.js",
   "scripts": {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -34,11 +34,19 @@ function getQueryPath(queries: string[]): string {
   return "?${qsStringify(queries)}";
 }
 
+let queryToTypeDef = (x: string) => {
+  if (x.endsWith("[]")) {
+    return `${x.replace(/\[\]$/, "")}?: string[]`;
+  } else {
+    return `${x}?: string`;
+  }
+};
+
 function getDefaultQueryTypes(queries: string[]): string {
   if (queries == null) {
     return "";
   }
-  let queryTypes = queries.map((k) => `${k}?:string`).join(", ");
+  let queryTypes = queries.map(queryToTypeDef).join(", ");
   return `{${queryTypes}}`;
 }
 
@@ -144,7 +152,7 @@ let generateTypesInterface = (rule: IRouteRule, baseType: string, inheritVariabl
       queries.push(query);
     }
   });
-  let queriesCode = queries.map((x) => `${x}: string`).join(",");
+  let queriesCode = queries.map(queryToTypeDef).join(",");
 
   let nextTypesCode = (rule.next || []).map((x) => `${baseType}[${formatPropName(x.path)}]`).join(" | ");
 

--- a/tests/generated/array-query.ts
+++ b/tests/generated/array-query.ts
@@ -1,0 +1,24 @@
+export let genRouter = {
+  a: {
+    name: "a",
+    raw: "a",
+    path: (queries?: IGenQueryA) => `/a?${qsStringify(queries)}`,
+    go: (queries?: IGenQueryA) => switchPath(`/a?${qsStringify(queries)}`),
+  },
+};
+
+export interface IGenQueryA {
+  b?: string;
+  c?: string[];
+}
+
+export type GenRouterTypeMain = GenRouterTypeTree["a"];
+
+export interface GenRouterTypeTree {
+  a: {
+    name: "a";
+    params: {};
+    query: { b?: string; c?: string[] };
+    next: null;
+  };
+}

--- a/tests/generated/types-nested.ts
+++ b/tests/generated/types-nested.ts
@@ -73,13 +73,13 @@ export interface GenRouterTypeTree {
       e: {
         name: "e";
         params: { cid: string };
-        query: { f: string };
+        query: { f?: string };
         next: null;
       };
       g_: {
         name: "g";
         params: { cid: string; gid: string };
-        query: { h: string };
+        query: { h?: string };
         next: null;
       };
     };

--- a/tests/generated/types-queries.ts
+++ b/tests/generated/types-queries.ts
@@ -34,18 +34,18 @@ export interface GenRouterTypeTree {
   a: {
     name: "a";
     params: {};
-    query: { a: string };
+    query: { a?: string };
     next: GenRouterTypeTree["a"]["b"] | GenRouterTypeTree["a"]["d"];
     b: {
       name: "b";
       params: {};
-      query: { a: string; b: string };
+      query: { a?: string; b?: string };
       next: null;
     };
     d: {
       name: "d";
       params: {};
-      query: { a: string };
+      query: { a?: string };
       next: null;
     };
   };

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -97,3 +97,11 @@ test("queries types", () => {
   let expectedCode = loadFile("generated/types-queries.ts");
   expect(formatted).toBe(expectedCode);
 });
+
+test("array queries", () => {
+  let rules = loadJSON("json/array-query.json");
+  let result = generateTree(rules, { addTypes: true });
+  let formatted = prettier.format(result, prettierConfigs);
+  let expectedCode = loadFile("generated/array-query.ts");
+  expect(formatted).toBe(expectedCode);
+});

--- a/tests/json/array-query.json
+++ b/tests/json/array-query.json
@@ -1,0 +1,1 @@
+[{ "name": "a", "path": "a", "queries": ["b", "c[]"] }]


### PR DESCRIPTION
Details https://github.com/jimengio/router-code-generator/issues/19 .

设计意图上需要 `arrayFormat: "bracket"` 的配置, 要 ruled-router 模块也跟这里保持统一.
