### PR TITLE
prettier code result in demo

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,7 +23,7 @@ window.addEventListener("hashchange", () => {
 declare var module: any;
 
 if (module.hot) {
-  module.hot.accept([], () => {
+  module.hot.accept(["./pages/container"], () => {
     renderApp();
   });
 }

--- a/src/pages/container.tsx
+++ b/src/pages/container.tsx
@@ -6,15 +6,23 @@ import { IRouteRule } from "@jimengio/ruled-router";
 import { row, fullscreen, column, rowMiddle, rowParted, flex, expand } from "@jimengio/flex-styles";
 import copy from "copy-to-clipboard";
 
+import parserTypeScript from "prettier/parser-typescript";
+import prettier from "prettier/standalone";
+
 let Container: FC<{}> = React.memo((props) => {
-  let [text, setText] = useState("");
+  let [text, setText] = useState(`[ { "path": "a" } ]`);
   let [result, setResult] = useState("");
 
   /** Methods */
 
   let changeCode = () => {
     try {
-      setResult(generateTree(JSON.parse(text) as IRouteRule[], { addTypes: true }));
+      setResult(
+        prettier.format(generateTree(JSON.parse(text) as IRouteRule[], { addTypes: true }), {
+          parser: "typescript",
+          plugins: [parserTypeScript],
+        })
+      );
     } catch (err) {
       setResult(err.message);
     }


### PR DESCRIPTION
http://fe.jimu.io/router-code-generator/ 现在加上了 standalone 版本的 prettier, 在浏览器环境运行, 对输出的代码结果进行格式化
