### PR TITLE
FR-170 inherit queries from parents; alpha release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/router-code-generator",
-  "version": "0.2.5",
+  "version": "0.2.6-a1",
   "description": "",
   "main": "./lib/generator.js",
   "scripts": {

--- a/tests/generated/inherit-queries.ts
+++ b/tests/generated/inherit-queries.ts
@@ -10,12 +10,6 @@ export let genRouter = {
       path: (queries?: IGenQueryAB) => `/a/b?${qsStringify(queries)}`,
       go: (queries?: IGenQueryAB) => switchPath(`/a/b?${qsStringify(queries)}`),
     },
-    d: {
-      name: "d",
-      raw: "d",
-      path: (queries?: IGenQueryAD) => `/a/d?${qsStringify(queries)}`,
-      go: (queries?: IGenQueryAD) => switchPath(`/a/d?${qsStringify(queries)}`),
-    },
   },
 };
 
@@ -24,12 +18,9 @@ export interface IGenQueryAB {
   b?: string;
 }
 
-export interface IGenQueryAD {
-  a?: string;
-}
-
 export interface IGenQueryA {
   a?: string;
+  b?: string;
 }
 
 export type GenRouterTypeMain = GenRouterTypeTree["a"];
@@ -38,18 +29,12 @@ export interface GenRouterTypeTree {
   a: {
     name: "a";
     params: {};
-    query: { a?: string };
-    next: GenRouterTypeTree["a"]["b"] | GenRouterTypeTree["a"]["d"];
+    query: { a?: string; b?: string };
+    next: GenRouterTypeTree["a"]["b"];
     b: {
       name: "b";
       params: {};
       query: { a?: string; b?: string };
-      next: null;
-    };
-    d: {
-      name: "d";
-      params: {};
-      query: { a?: string };
       next: null;
     };
   };

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -105,3 +105,11 @@ test("array queries", () => {
   let expectedCode = loadFile("generated/array-query.ts");
   expect(formatted).toBe(expectedCode);
 });
+
+test("inherit queries", () => {
+  let rules = loadJSON("json/inherit-queries.json");
+  let result = generateTree(rules, { addTypes: true });
+  let formatted = prettier.format(result, prettierConfigs);
+  let expectedCode = loadFile("generated/inherit-queries.ts");
+  expect(formatted).toBe(expectedCode);
+});

--- a/tests/json/inherit-queries.json
+++ b/tests/json/inherit-queries.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "a",
+    "path": "a",
+    "queries": ["a", "b"],
+    "next": [
+      {
+        "path": "b"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
参考测试用例, 父级的规则当中定义了 queries, 子路由当中进行继承,

```json
[
  {
    "name": "a",
    "path": "a",
    "queries": ["a", "b"],
    "next": [
      {
        "path": "b"
      }
    ]
  }
]
```

这次修改在生成路由跳转的代码当中.
